### PR TITLE
Use fully-qualified DB names in LookML

### DIFF
--- a/ecomm_dash/inventory_items.view.lkml
+++ b/ecomm_dash/inventory_items.view.lkml
@@ -1,5 +1,5 @@
 view: inventory_items {
-  sql_table_name: `looker_ecomm`.inventory_items
+  sql_table_name: `cloud-training-demos.looker_ecomm.inventory_items`
     ;;
   drill_fields: [id]
 

--- a/ecomm_dash/order_items.view.lkml
+++ b/ecomm_dash/order_items.view.lkml
@@ -1,5 +1,5 @@
 view: order_items {
-  sql_table_name: `looker_ecomm`.order_items
+  sql_table_name: `cloud-training-demos.looker_ecomm.order_items`
     ;;
   drill_fields: [id]
 

--- a/ecomm_dash/products.view.lkml
+++ b/ecomm_dash/products.view.lkml
@@ -1,5 +1,5 @@
 view: products {
-  sql_table_name: `looker_ecomm`.products
+  sql_table_name: `cloud-training-demos.looker_ecomm.products`
     ;;
   drill_fields: [id]
 

--- a/ecomm_dash/users.view.lkml
+++ b/ecomm_dash/users.view.lkml
@@ -1,5 +1,5 @@
 view: users {
-  sql_table_name: `looker_ecomm`.users
+  sql_table_name: `cloud-training-demos.looker_ecomm.users`
     ;;
   drill_fields: [id]
 

--- a/general/flights/aircraft.view.lkml
+++ b/general/flights/aircraft.view.lkml
@@ -1,5 +1,5 @@
 view: aircraft {
-  sql_table_name: `looker_flights`.aircraft ;;
+  sql_table_name: `cloud-training-demos.looker_flights.aircraft` ;;
 
   dimension: tail_num {
     type: string

--- a/general/flights/airports.view.lkml
+++ b/general/flights/airports.view.lkml
@@ -1,5 +1,5 @@
 view: airports {
-  sql_table_name: `looker_flights`.airports ;;
+  sql_table_name: `cloud-training-demos.looker_flights.airports` ;;
 
   dimension: id {
     primary_key: yes

--- a/general/flights/carriers.view.lkml
+++ b/general/flights/carriers.view.lkml
@@ -1,5 +1,5 @@
 view: carriers {
-  sql_table_name: `looker_flights`.carriers ;;
+  sql_table_name: `cloud-training-demos.looker_flights.carriers` ;;
 
   dimension: code {
     primary_key: yes

--- a/general/flights/flights.view.lkml
+++ b/general/flights/flights.view.lkml
@@ -1,6 +1,6 @@
 
 view: flights {
-  sql_table_name: `looker_flights`.flights ;;
+  sql_table_name: `cloud-training-demos.looker_flights.flights` ;;
 
  dimension: id {
     primary_key: yes


### PR DESCRIPTION
Use fully-qualified names (https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#table_name) for all BigQuery tables so the LookML files work when executed from a project other than cloud-training-demos.